### PR TITLE
v4 token handling refactors

### DIFF
--- a/4_client_server_db_jwt/client/src/App.jsx
+++ b/4_client_server_db_jwt/client/src/App.jsx
@@ -2,11 +2,10 @@ import React, { Suspense, useEffect, useState } from "react";
 import { useAuth } from "./providers/authProvider";
 import { refreshFetch } from "./api";
 import Routes from "./routes/Routes";
-import TokenVerify from "./routes/TokenVerify";
 import GridLoader from "react-spinners/GridLoader";
 
 function App() {
-  const { token, setToken } = useAuth();
+  const { setToken } = useAuth();
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {

--- a/4_client_server_db_jwt/client/src/App.jsx
+++ b/4_client_server_db_jwt/client/src/App.jsx
@@ -1,6 +1,6 @@
 import React, { Suspense, useEffect, useState } from "react";
 import { useAuth } from "./providers/authProvider";
-import { authenticateFetch } from "./api";
+import { refreshFetch } from "./api";
 import Routes from "./routes/Routes";
 import GridLoader from "react-spinners/GridLoader";
 
@@ -10,8 +10,8 @@ function App() {
 
   useEffect(() => {
     setIsLoading(true);
-    const fetchAuth = async () => {
-      const res = await authenticateFetch();
+    const fetchRefresh = async () => {
+      const res = await refreshFetch();
       if (res.ok) {
         const tokenJSON = await res.json();
         setToken(tokenJSON);
@@ -21,7 +21,7 @@ function App() {
       setIsLoading(false);
     };
 
-    fetchAuth();
+    fetchRefresh();
   }, []);
 
   if (isLoading) return <GridLoader />;

--- a/4_client_server_db_jwt/client/src/App.jsx
+++ b/4_client_server_db_jwt/client/src/App.jsx
@@ -2,6 +2,7 @@ import React, { Suspense, useEffect, useState } from "react";
 import { useAuth } from "./providers/authProvider";
 import { refreshFetch } from "./api";
 import Routes from "./routes/Routes";
+import TokenVerify from "./routes/TokenVerify";
 import GridLoader from "react-spinners/GridLoader";
 
 function App() {

--- a/4_client_server_db_jwt/client/src/api/authentication.js
+++ b/4_client_server_db_jwt/client/src/api/authentication.js
@@ -32,6 +32,6 @@ export const logoutFetch = async () => {
   return fetch("/logout", config);
 };
 
-export const authenticateFetch = async () => {
-  return fetch("/authenticate");
+export const refreshFetch = async () => {
+  return fetch("/refresh");
 };

--- a/4_client_server_db_jwt/client/src/api/authentication.js
+++ b/4_client_server_db_jwt/client/src/api/authentication.js
@@ -1,5 +1,3 @@
-// TODO: Handle expired tokens with redirects to login page
-
 export const registerFetch = async (formData) => {
   const config = {
     method: "POST",

--- a/4_client_server_db_jwt/client/src/api/game.js
+++ b/4_client_server_db_jwt/client/src/api/game.js
@@ -1,5 +1,3 @@
-// TODO: Handle expired tokens with redirects to login page
-
 export const gamesFetch = async () => {
   return fetch("/games");
 };
@@ -44,6 +42,6 @@ export const newRoundByGameIdFetch = async (id) => {
     headers: {
       "Content-Type": "application/json",
     },
-  }
+  };
   return fetch(`/games/${id}/rounds`, config);
-}
+};

--- a/4_client_server_db_jwt/client/src/api/index.js
+++ b/4_client_server_db_jwt/client/src/api/index.js
@@ -11,7 +11,7 @@ import {
   gamesByIdFetch,
   deleteGamesByIdFetch,
   roundsByGameIdFetch,
-  newRoundByGameIdFetch
+  newRoundByGameIdFetch,
 } from "./game";
 export {
   registerFetch,
@@ -24,5 +24,5 @@ export {
   gamesByIdFetch,
   deleteGamesByIdFetch,
   roundsByGameIdFetch,
-  newRoundByGameIdFetch
+  newRoundByGameIdFetch,
 };

--- a/4_client_server_db_jwt/client/src/api/index.js
+++ b/4_client_server_db_jwt/client/src/api/index.js
@@ -2,7 +2,7 @@ import {
   registerFetch,
   loginFetch,
   logoutFetch,
-  authenticateFetch,
+  refreshFetch,
 } from "./authentication";
 import {
   gamesFetch,
@@ -17,7 +17,7 @@ export {
   registerFetch,
   loginFetch,
   logoutFetch,
-  authenticateFetch,
+  refreshFetch,
   gamesFetch,
   postGamesFetch,
   patchGamesFetch,

--- a/4_client_server_db_jwt/client/src/components/Authentication.jsx
+++ b/4_client_server_db_jwt/client/src/components/Authentication.jsx
@@ -9,7 +9,7 @@ import { registerFetch, loginFetch } from "../api";
 import StatusDetail from "./StatusDetail";
 
 export default function Authentication() {
-  const { setToken } = useAuth();
+  const { setToken, setLoading } = useAuth();
   const navigate = useNavigate();
   const [isSignup, setIsSignup] = useState(false);
   const [isError, setIsError] = useState(false);
@@ -24,6 +24,7 @@ export default function Authentication() {
   });
 
   const handleSubmit = async (values, setSubmitting) => {
+    setLoading(true);
     setMessage("");
     setIsError(false);
     if (isSignup) {
@@ -40,7 +41,8 @@ export default function Authentication() {
         setIsError(true);
         setMessage(resJSON);
       } else {
-        setToken(resJSON);
+        await setToken(resJSON);
+        setLoading(false)
         navigate("/dashboard");
       }
     }

--- a/4_client_server_db_jwt/client/src/components/Dashboard.jsx
+++ b/4_client_server_db_jwt/client/src/components/Dashboard.jsx
@@ -4,13 +4,15 @@ import GameCard from "./GameCard";
 import GridLoader from "react-spinners/GridLoader";
 import { gamesFetch, deleteGamesByIdFetch } from "../api";
 import { useGames } from "../providers/gamesProvider";
+import { useAuth } from "../providers/authProvider";
 import StatusDetail from "./StatusDetail";
 
 function Dashboard() {
   const [isError, setIsError] = useState(false);
   const [message, setMessage] = useState("");
   const { games, setGames } = useGames();
-  
+  const { isTokenExpired } = useAuth();
+
   useEffect(() => {
     const fetchGames = async () => {
       setMessage("");
@@ -28,8 +30,10 @@ function Dashboard() {
         });
       }
     };
-    fetchGames();
-  }, []);
+    if (!isTokenExpired()) {
+      fetchGames();
+    }
+  }, [isTokenExpired, setGames]);
 
   async function deleteGame(id) {
     const res = await deleteGamesByIdFetch(id);
@@ -46,10 +50,10 @@ function Dashboard() {
   }
 
   let gameCards = games
-  .sort((a, b) => a.number - b.number) // sort by number
-  .map((game) => (
-    <GameCard key={game.id} game={game} onDelete={deleteGame} />
-  ));
+    .sort((a, b) => a.number - b.number) // sort by number
+    .map((game) => (
+      <GameCard key={game.id} game={game} onDelete={deleteGame} />
+    ));
 
   return (
     <>

--- a/4_client_server_db_jwt/client/src/components/Dashboard.jsx
+++ b/4_client_server_db_jwt/client/src/components/Dashboard.jsx
@@ -33,7 +33,7 @@ function Dashboard() {
     if (!isTokenExpired()) {
       fetchGames();
     }
-  }, [isTokenExpired, setGames]);
+  }, [isTokenExpired]);
 
   async function deleteGame(id) {
     const res = await deleteGamesByIdFetch(id);

--- a/4_client_server_db_jwt/client/src/components/Dashboard.jsx
+++ b/4_client_server_db_jwt/client/src/components/Dashboard.jsx
@@ -4,12 +4,15 @@ import GameCard from "./GameCard";
 import GridLoader from "react-spinners/GridLoader";
 import { gamesFetch, deleteGamesByIdFetch } from "../api";
 import { useGames } from "../providers/gamesProvider";
+import { useAuth } from "../providers/authProvider";
 import StatusDetail from "./StatusDetail";
 
 function Dashboard() {
   const [isError, setIsError] = useState(false);
   const [message, setMessage] = useState("");
   const { games, setGames } = useGames();
+  const { isTokenExpired } = useAuth();
+  console.log("🚀 ~ file: Dashboard.jsx:15 ~ Dashboard ~ isTokenExpired:", isTokenExpired())
 
   useEffect(() => {
     const fetchGames = async () => {
@@ -46,7 +49,9 @@ function Dashboard() {
     }
   }
 
-  let gameCards = games.map((game) => (
+  let gameCards = games
+  .sort((a, b) => a.number - b.number) // sort by number
+  .map((game) => (
     <GameCard key={game.id} game={game} onDelete={deleteGame} />
   ));
 

--- a/4_client_server_db_jwt/client/src/components/Dashboard.jsx
+++ b/4_client_server_db_jwt/client/src/components/Dashboard.jsx
@@ -4,18 +4,13 @@ import GameCard from "./GameCard";
 import GridLoader from "react-spinners/GridLoader";
 import { gamesFetch, deleteGamesByIdFetch } from "../api";
 import { useGames } from "../providers/gamesProvider";
-import { useAuth } from "../providers/authProvider";
-import { useNavigate } from "react-router-dom";
 import StatusDetail from "./StatusDetail";
 
 function Dashboard() {
   const [isError, setIsError] = useState(false);
   const [message, setMessage] = useState("");
   const { games, setGames } = useGames();
-  const { isTokenExpired } = useAuth();
-  console.log("🚀 ~ file: Dashboard.jsx:15 ~ Dashboard ~ isTokenExpired:", isTokenExpired())
-  const navigate = useNavigate();
-
+  
   useEffect(() => {
     const fetchGames = async () => {
       setMessage("");
@@ -33,11 +28,7 @@ function Dashboard() {
         });
       }
     };
-    if (!isTokenExpired()) {
-      fetchGames();
-    } else {
-      navigate("/login");
-    }
+    fetchGames();
   }, []);
 
   async function deleteGame(id) {

--- a/4_client_server_db_jwt/client/src/components/Dashboard.jsx
+++ b/4_client_server_db_jwt/client/src/components/Dashboard.jsx
@@ -5,6 +5,7 @@ import GridLoader from "react-spinners/GridLoader";
 import { gamesFetch, deleteGamesByIdFetch } from "../api";
 import { useGames } from "../providers/gamesProvider";
 import { useAuth } from "../providers/authProvider";
+import { useNavigate } from "react-router-dom";
 import StatusDetail from "./StatusDetail";
 
 function Dashboard() {
@@ -13,6 +14,7 @@ function Dashboard() {
   const { games, setGames } = useGames();
   const { isTokenExpired } = useAuth();
   console.log("🚀 ~ file: Dashboard.jsx:15 ~ Dashboard ~ isTokenExpired:", isTokenExpired())
+  const navigate = useNavigate();
 
   useEffect(() => {
     const fetchGames = async () => {
@@ -31,8 +33,11 @@ function Dashboard() {
         });
       }
     };
-
-    fetchGames();
+    if (!isTokenExpired()) {
+      fetchGames();
+    } else {
+      navigate("/login");
+    }
   }, []);
 
   async function deleteGame(id) {

--- a/4_client_server_db_jwt/client/src/components/GameDetail.jsx
+++ b/4_client_server_db_jwt/client/src/components/GameDetail.jsx
@@ -70,14 +70,16 @@ function GameDetail() {
         <h2>Game {game.id}</h2>
         <div className="roundList">
           <ul>
-            {rounds.reverse().map((round, index) => (
-              <RoundCard
-                key={index}
-                round={round}
-                game={game}
-                onGuessRequest={handleUpdateGame}
-              />
-            ))}
+            {rounds
+              .sort((a, b) => b.number - a.number)
+              .map((round, index) => (
+                <RoundCard
+                  key={index}
+                  round={round}
+                  game={game}
+                  onGuessRequest={handleUpdateGame}
+                />
+              ))}
           </ul>
         </div>
       </div>

--- a/4_client_server_db_jwt/client/src/components/GameDetail.jsx
+++ b/4_client_server_db_jwt/client/src/components/GameDetail.jsx
@@ -2,7 +2,12 @@ import React, { useState, useEffect, useCallback, Suspense } from "react";
 import { useParams } from "react-router-dom";
 import GridLoader from "react-spinners/GridLoader";
 import RoundCard from "./RoundCard";
-import { gamesByIdFetch, roundsByGameIdFetch, newRoundByGameIdFetch } from "../api";
+import {
+  gamesByIdFetch,
+  roundsByGameIdFetch,
+  newRoundByGameIdFetch,
+} from "../api";
+import { useAuth } from "../providers/authProvider";
 
 function GameDetail() {
   const [game, setGame] = useState({ secret_number: 0 });
@@ -10,6 +15,7 @@ function GameDetail() {
   const [error, setError] = useState(null);
   const [status, setStatus] = useState("pending");
   const { id } = useParams();
+  const { isTokenExpired } = useAuth();
 
   const fetchGame = useCallback(async () => {
     const res = await gamesByIdFetch(id);
@@ -44,10 +50,12 @@ function GameDetail() {
   }, [id]);
 
   useEffect(() => {
-    fetchGame().catch(console.error);
-    fetchRounds().catch(console.error);
-  }, [id, fetchGame, fetchRounds]);
-  
+    if (!isTokenExpired()) {
+      fetchGame().catch(console.error);
+      fetchRounds().catch(console.error);
+    }
+  }, [id, fetchGame, fetchRounds, isTokenExpired]);
+
   function handleUpdateGame() {
     fetchGame().catch(console.error);
     fetchRounds().catch(console.error);

--- a/4_client_server_db_jwt/client/src/components/NavMenu.jsx
+++ b/4_client_server_db_jwt/client/src/components/NavMenu.jsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Menu, MenuItem, IconButton, Link } from "@mui/material";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
-import { Link as RouterLink } from "react-router-dom";
+import { Link as RouterLink, useNavigate } from "react-router-dom";
 import { useAuth } from "../providers/authProvider";
 import { logoutFetch } from "../api";
 
@@ -14,12 +14,16 @@ export default function NavMenu() {
   const handleClose = () => {
     setAnchorEl(null);
   };
+  const navigate = useNavigate();
   const { setToken } = useAuth();
 
   const handleLogout = async () => {
     handleClose();
     const res = await logoutFetch();
-    if (res.ok) setToken(null);
+    if (res.ok) {
+      setToken(null);
+      navigate("/login");
+    }
   };
 
   return (

--- a/4_client_server_db_jwt/client/src/providers/authProvider.js
+++ b/4_client_server_db_jwt/client/src/providers/authProvider.js
@@ -10,14 +10,15 @@ const AuthContext = createContext();
 
 const AuthProvider = ({ children }) => {
   const [token, setToken_] = useState(null);
+  const [loading, setLoading_] = useState(false);
   const isTokenExpired = useCallback(() => {
     if (!token) {
-      return true;
+      return null;
     }
     const payload = token.access_token.split(".")[1];
     const { exp } = JSON.parse(atob(payload));
     if (!exp) {
-      return true;
+      return null;
     }
 
     return Date.now() >= exp * 1000;
@@ -25,7 +26,8 @@ const AuthProvider = ({ children }) => {
 
   const contextValue = useMemo(() => {
     const setToken = (newToken) => setToken_(newToken);
-    return { token, setToken, isTokenExpired };
+    const setLoading = (newLoading) => setLoading_(newLoading);
+    return { token, setToken, isTokenExpired, loading, setLoading };
   }, [token, isTokenExpired]);
 
   return (

--- a/4_client_server_db_jwt/client/src/providers/authProvider.js
+++ b/4_client_server_db_jwt/client/src/providers/authProvider.js
@@ -4,10 +4,22 @@ const AuthContext = createContext();
 
 const AuthProvider = ({ children }) => {
   const [token, setToken_] = useState(null);
+  const isTokenExpired = () => {
+    if (!token) {
+      return true;
+    }
+    const payload = token.access_token.split('.')[1];
+    const { exp } = JSON.parse(atob(payload));
+    if (!exp) {
+      return true;
+    }
+  
+    return Date.now() >= exp * 1000;
+  }
 
   const contextValue = useMemo(() => {
     const setToken = (newToken) => setToken_(newToken);
-    return { token, setToken };
+    return { token, setToken, isTokenExpired };
   }, [token]);
 
   return (

--- a/4_client_server_db_jwt/client/src/providers/authProvider.js
+++ b/4_client_server_db_jwt/client/src/providers/authProvider.js
@@ -1,26 +1,32 @@
-import { createContext, useContext, useMemo, useState } from "react";
+import {
+  createContext,
+  useContext,
+  useMemo,
+  useState,
+  useCallback,
+} from "react";
 
 const AuthContext = createContext();
 
 const AuthProvider = ({ children }) => {
   const [token, setToken_] = useState(null);
-  const isTokenExpired = () => {
+  const isTokenExpired = useCallback(() => {
     if (!token) {
       return true;
     }
-    const payload = token.access_token.split('.')[1];
+    const payload = token.access_token.split(".")[1];
     const { exp } = JSON.parse(atob(payload));
     if (!exp) {
       return true;
     }
-  
+
     return Date.now() >= exp * 1000;
-  }
+  }, [token]);
 
   const contextValue = useMemo(() => {
     const setToken = (newToken) => setToken_(newToken);
     return { token, setToken, isTokenExpired };
-  }, [token]);
+  }, [token, isTokenExpired]);
 
   return (
     <AuthContext.Provider value={contextValue}>{children}</AuthContext.Provider>

--- a/4_client_server_db_jwt/client/src/routes/Routes.jsx
+++ b/4_client_server_db_jwt/client/src/routes/Routes.jsx
@@ -8,7 +8,7 @@ import GameDetail from "../components/GameDetail";
 import GameForm from "../components/GameForm";
 
 const Routes = () => {
-  const { token } = useAuth();
+  const { token, isTokenExpired } = useAuth();
 
   const routesForAuthenticated = [
     {
@@ -43,7 +43,7 @@ const Routes = () => {
   ];
 
   const router = createBrowserRouter([
-    ...(!token ? routesForUnauthenticated : []),
+    ...((!token || isTokenExpired()) ? routesForUnauthenticated : []),
     ...routesForAuthenticated,
   ]);
 

--- a/4_client_server_db_jwt/client/src/routes/Routes.jsx
+++ b/4_client_server_db_jwt/client/src/routes/Routes.jsx
@@ -43,17 +43,35 @@ const Routes = () => {
     },
   ];
 
+  const allRoutes = [
+    {
+      path: "dashboard",
+      element: <Dashboard />,
+    },
+    {
+      path: "games/:id",
+      element: <GameDetail />,
+    },
+    {
+      path: "games/new",
+      element: <GameForm />,
+    },
+    {
+      path: "login",
+      element: <Authentication />,
+    },
+  ]
+
   const publicRoutes = [
     {
       path: "/",
       element: <TokenVerify />,
       children: [
-        ...(!token || isTokenExpired() ? routesForUnauthenticated : []),
-        ...routesForAuthenticated,
+        ...allRoutes,
       ],
     },
   ];
-
+  
   const router = createBrowserRouter([...publicRoutes]);
 
   return <RouterProvider router={router} />;

--- a/4_client_server_db_jwt/client/src/routes/Routes.jsx
+++ b/4_client_server_db_jwt/client/src/routes/Routes.jsx
@@ -6,31 +6,33 @@ import Authentication from "../components/Authentication";
 import Dashboard from "../components/Dashboard";
 import GameDetail from "../components/GameDetail";
 import GameForm from "../components/GameForm";
+import TokenVerify from "./TokenVerify";
 
 const Routes = () => {
   const { token, isTokenExpired } = useAuth();
 
+  
   const routesForAuthenticated = [
     {
       path: "/",
       element: <ProtectedRoute />,
       children: [
         {
-          path: "/dashboard",
+          path: "dashboard",
           element: <Dashboard />,
         },
         {
-          path: "/games/:id",
+          path: "games/:id",
           element: <GameDetail />,
         },
         {
-          path: "/games/new",
+          path: "games/new",
           element: <GameForm />,
         },
       ],
     },
   ];
-
+  
   const routesForUnauthenticated = [
     {
       path: "/",
@@ -41,10 +43,20 @@ const Routes = () => {
       element: <Authentication />,
     },
   ];
+  
+  const publicRoutes = [
+    {
+      path: "/",
+      element: <TokenVerify />,
+      children: [
+        ...((!token || isTokenExpired()) ? routesForUnauthenticated : []),
+        ...routesForAuthenticated,
+      ]
+    }
+  ];
 
   const router = createBrowserRouter([
-    ...((!token || isTokenExpired()) ? routesForUnauthenticated : []),
-    ...routesForAuthenticated,
+    ...publicRoutes,
   ]);
 
   return <RouterProvider router={router} />;

--- a/4_client_server_db_jwt/client/src/routes/Routes.jsx
+++ b/4_client_server_db_jwt/client/src/routes/Routes.jsx
@@ -11,7 +11,6 @@ import TokenVerify from "./TokenVerify";
 const Routes = () => {
   const { token, isTokenExpired } = useAuth();
 
-  
   const routesForAuthenticated = [
     {
       path: "/",
@@ -32,7 +31,7 @@ const Routes = () => {
       ],
     },
   ];
-  
+
   const routesForUnauthenticated = [
     {
       path: "/",
@@ -43,21 +42,19 @@ const Routes = () => {
       element: <Authentication />,
     },
   ];
-  
+
   const publicRoutes = [
     {
       path: "/",
       element: <TokenVerify />,
       children: [
-        ...((!token || isTokenExpired()) ? routesForUnauthenticated : []),
+        ...(!token || isTokenExpired() ? routesForUnauthenticated : []),
         ...routesForAuthenticated,
-      ]
-    }
+      ],
+    },
   ];
 
-  const router = createBrowserRouter([
-    ...publicRoutes,
-  ]);
+  const router = createBrowserRouter([...publicRoutes]);
 
   return <RouterProvider router={router} />;
 };

--- a/4_client_server_db_jwt/client/src/routes/TokenVerify.jsx
+++ b/4_client_server_db_jwt/client/src/routes/TokenVerify.jsx
@@ -1,37 +1,49 @@
-import React, { useEffect, useState } from 'react'
-import {useLocation, useNavigation, Outlet} from 'react-router-dom'
-import {useAuth} from '../providers/authProvider'
-import StatusDetail from '../components/StatusDetail'
-
+import React, { useEffect, useState } from "react";
+import { useLocation, useNavigate, Outlet } from "react-router-dom";
+import { useAuth } from "../providers/authProvider";
+import StatusDetail from "../components/StatusDetail";
+import { logoutFetch } from "../api";
 
 function TokenVerify() {
-  const [ message, setMessage ] = useState('')
- 
-  const { isTokenExpired } = useAuth()
+  const [message, setMessage] = useState("");
 
-  const location = useLocation()
+  const { isTokenExpired } = useAuth();
 
-  const navigate = useNavigation()
+  const location = useLocation();
 
+  const navigate = useNavigate();
+
+  // If the token is expired, set a message and log the user out after 10 seconds.
+  // Extensible to show a modal to the user to ask if they want to stay logged in, display countdown, etc.
   useEffect(() => {
-    console.log("🚀 ~ file: TokenVerify.jsx:15 ~ useEffect ~ isTokenExpired():", isTokenExpired())
     if (isTokenExpired()) {
-     setMessage('You will be logged out in 10 seconds due to inactivity.')
+      setMessage({
+        message: "You will be logged out in 10 seconds due to inactivity.",
+      });
+      setTimeout(async () => {
+        const res = await logoutFetch();
+        if (res.ok) {
+          setMessage("");
+          navigate("/login");
+        } else {
+          setMessage("Logout failed.");
+        }
+      }, 10000);
     }
-  }, [location, navigate, isTokenExpired])
+  }, [location, navigate, isTokenExpired]);
 
   return (
     <>
-      {message && 
+      {message && (
         <StatusDetail
           message={message}
           isError={true}
-          onCloseHandler={() => setMessage('')}
+          onCloseHandler={() => setMessage("")}
         />
-      }
+      )}
       <Outlet />
     </>
-  )
+  );
 }
 
-export default TokenVerify
+export default TokenVerify;

--- a/4_client_server_db_jwt/client/src/routes/TokenVerify.jsx
+++ b/4_client_server_db_jwt/client/src/routes/TokenVerify.jsx
@@ -2,21 +2,37 @@ import React, { useEffect, useState } from "react";
 import { useLocation, useNavigate, Outlet } from "react-router-dom";
 import { useAuth } from "../providers/authProvider";
 import StatusDetail from "../components/StatusDetail";
+import NavMenu from "../components/NavMenu";
 import { logoutFetch } from "../api";
 
 function TokenVerify() {
   const [message, setMessage] = useState("");
 
-  const { isTokenExpired } = useAuth();
+  const { token, isTokenExpired, loading } = useAuth();
 
   const location = useLocation();
-
   const navigate = useNavigate();
+
+  // redirects index "/" routes conditionally based on login status
+  useEffect(() => {
+    if (location.pathname == "/" && !loading) {
+      if (token) {
+        navigate("/dashboard");
+      } else {
+        navigate("/login");
+      }
+    }
+  }, [token]);
 
   // If the token is expired, set a message and log the user out after 10 seconds.
   // Extensible to show a modal to the user to ask if they want to stay logged in, display countdown, etc.
   useEffect(() => {
     if (isTokenExpired() && location.pathname !== "/login") {
+      console.log(
+        "🚀 ~ file: TokenVerify.jsx:22 ~ useEffect ~ pathname:",
+        location.pathname
+      );
+
       setMessage({
         message: "You will be logged out in 10 seconds due to inactivity.",
       });
@@ -30,7 +46,7 @@ function TokenVerify() {
         }
       }, 10000);
     }
-  }, [location, navigate, isTokenExpired]);
+  }, [location, isTokenExpired]);
 
   return (
     <>
@@ -41,6 +57,7 @@ function TokenVerify() {
           onCloseHandler={() => setMessage("")}
         />
       )}
+      <NavMenu />
       <Outlet />
     </>
   );

--- a/4_client_server_db_jwt/client/src/routes/TokenVerify.jsx
+++ b/4_client_server_db_jwt/client/src/routes/TokenVerify.jsx
@@ -1,0 +1,37 @@
+import React, { useEffect, useState } from 'react'
+import {useLocation, useNavigation, Outlet} from 'react-router-dom'
+import {useAuth} from '../providers/authProvider'
+import StatusDetail from '../components/StatusDetail'
+
+
+function TokenVerify() {
+  const [ message, setMessage ] = useState('')
+ 
+  const { isTokenExpired } = useAuth()
+
+  const location = useLocation()
+
+  const navigate = useNavigation()
+
+  useEffect(() => {
+    console.log("🚀 ~ file: TokenVerify.jsx:15 ~ useEffect ~ isTokenExpired():", isTokenExpired())
+    if (isTokenExpired()) {
+     setMessage('You will be logged out in 10 seconds due to inactivity.')
+    }
+  }, [location, navigate, isTokenExpired])
+
+  return (
+    <>
+      {message && 
+        <StatusDetail
+          message={message}
+          isError={true}
+          onCloseHandler={() => setMessage('')}
+        />
+      }
+      <Outlet />
+    </>
+  )
+}
+
+export default TokenVerify

--- a/4_client_server_db_jwt/client/src/routes/TokenVerify.jsx
+++ b/4_client_server_db_jwt/client/src/routes/TokenVerify.jsx
@@ -16,7 +16,7 @@ function TokenVerify() {
   // If the token is expired, set a message and log the user out after 10 seconds.
   // Extensible to show a modal to the user to ask if they want to stay logged in, display countdown, etc.
   useEffect(() => {
-    if (isTokenExpired()) {
+    if (isTokenExpired() && location.pathname !== "/login") {
       setMessage({
         message: "You will be logged out in 10 seconds due to inactivity.",
       });

--- a/4_client_server_db_jwt/server/app.py
+++ b/4_client_server_db_jwt/server/app.py
@@ -1,16 +1,23 @@
 #!/usr/bin/env python3
-from flask import Flask, redirect
-from flask_migrate import Migrate
-from flask_smorest import Api
-from flask_jwt_extended import JWTManager
 import warnings
-from sqlalchemy import select
+from datetime import datetime, timedelta
 
 from db import db
-from models import TokenBlocklist, User
 from default_config import DefaultConfig
+from flask import Flask, redirect
+from flask_jwt_extended import (
+    JWTManager,
+    create_access_token,
+    get_jwt,
+    get_jwt_identity,
+    set_access_cookies,
+)
+from flask_migrate import Migrate
+from flask_smorest import Api
+from models import TokenBlocklist, User
 from resources.game import blp as GameBlueprint
 from resources.user import blp as UserBlueprint
+from sqlalchemy import select
 
 app = Flask(__name__)
 app.config.from_object(DefaultConfig)
@@ -21,28 +28,28 @@ db.init_app(app)
 
 # Prevent warnings about nested schemas
 with app.app_context():
-    warnings.filterwarnings(
-            "ignore",
-            message="Multiple schemas resolved to the name "
-        )
+    warnings.filterwarnings("ignore", message="Multiple schemas resolved to the name ")
 
 
 # Create JWTManager
 jwt = JWTManager(app)
 
+
 # Callback function to check if a JWT exists in the database blocklist
 @jwt.token_in_blocklist_loader
 def check_if_token_revoked(jwt_header, jwt_payload):
     jti = jwt_payload["jti"]
-    token =  db.session.scalars(
+    token = db.session.scalars(
         select(TokenBlocklist).where(TokenBlocklist.jti == jti)
-        ).one_or_none()
+    ).one_or_none()
     return token is not None
+
 
 @jwt.revoked_token_loader
 def revoked_token_callback(jwt_header, jwt_payload):
-    return {"description": "The token has been revoked.", "error": "token_revoked"},   401
-    
+    return {"description": "The token has been revoked.", "error": "token_revoked"}, 401
+
+
 # Register a callback function that takes whatever object is passed in as the
 # identity when creating JWTs and converts it to a JSON serializable format.
 @jwt.user_identity_loader
@@ -54,10 +61,9 @@ def user_identity_lookup(user):
 # a protected route is accessed.
 @jwt.user_lookup_loader
 def user_lookup_callback(_jwt_header, jwt_payload):
-    identity = jwt_payload["sub"]    #subject of the jwt i.e. the user
-    return db.session.scalars(
-        select(User).where(User.id == identity)
-        ).one_or_none()
+    identity = jwt_payload["sub"]  # subject of the jwt i.e. the user
+    return db.session.scalars(select(User).where(User.id == identity)).one_or_none()
+
 
 # Create the API
 api = Api(app)
@@ -68,21 +74,41 @@ api.register_blueprint(UserBlueprint)
 
 # Add authorize button to OpenAPI document
 api.spec.components.security_scheme(
-    "bearerAuth", {"type":"http", "scheme": "bearer", "bearerFormat": "JWT"}
+    "bearerAuth", {"type": "http", "scheme": "bearer", "bearerFormat": "JWT"}
 )
-#Uncomment to add lock icon to all endpoints 
-#api.spec.options["security"] = [{"bearerAuth": []}]
+# Uncomment to add lock icon to all endpoints
+# api.spec.options["security"] = [{"bearerAuth": []}]
 
-#add lock icon to endpoints documented with @blp.doc(authorize=True)
+# add lock icon to endpoints documented with @blp.doc(authorize=True)
 for path, items in api.spec._paths.items():
-        for method in items.keys():
-            endpoint = api.spec._paths[path][method]
-            if type(endpoint) is dict and endpoint.get("authorize"):
-                api.spec._paths[path][method]["security"] = [{"bearerAuth": []}]
-    
-@app.route('/')
+    for method in items.keys():
+        endpoint = api.spec._paths[path][method]
+        if type(endpoint) is dict and endpoint.get("authorize"):
+            api.spec._paths[path][method]["security"] = [{"bearerAuth": []}]
+
+
+@app.route("/")
 def index():
     return redirect(app.config["OPENAPI_SWAGGER_UI_PATH"])
 
-if __name__ == '__main__':
+
+# Using an `after_request` callback, we refresh any token that is within 15
+# minutes of expiring.
+@app.after_request
+def refresh_expiring_jwts(response):
+    try:
+        # print("refreshing token")
+        exp_timestamp = get_jwt()["exp"]
+        now = datetime.utcnow()
+        target_timestamp = datetime.timestamp(now + timedelta(minutes=15))
+        if target_timestamp > exp_timestamp:
+            access_token = create_access_token(identity=get_jwt_identity(), fresh=False)
+            set_access_cookies(response, access_token)
+        return response
+    except (RuntimeError, KeyError):
+        # Case where there is not a valid JWT. Just return the original respone
+        return response
+
+
+if __name__ == "__main__":
     app.run(port=5555, debug=True)

--- a/4_client_server_db_jwt/server/app.py
+++ b/4_client_server_db_jwt/server/app.py
@@ -8,8 +8,8 @@ from flask import Flask, redirect
 from flask_jwt_extended import (
     JWTManager,
     create_access_token,
+    current_user,
     get_jwt,
-    get_jwt_identity,
     set_access_cookies,
 )
 from flask_migrate import Migrate
@@ -102,7 +102,7 @@ def refresh_expiring_jwts(response):
         now = datetime.utcnow()
         target_timestamp = datetime.timestamp(now + timedelta(minutes=15))
         if target_timestamp > exp_timestamp:
-            access_token = create_access_token(identity=get_jwt_identity(), fresh=False)
+            access_token = create_access_token(identity=current_user)
             set_access_cookies(response, access_token)
         return response
     except (RuntimeError, KeyError):

--- a/4_client_server_db_jwt/server/default_config.py
+++ b/4_client_server_db_jwt/server/default_config.py
@@ -19,7 +19,8 @@ class DefaultConfig:
         "postgresql://postgres:postgres@localhost:5432/flatiron_labs"
     )
     JWT_SECRET_KEY = str(secrets.SystemRandom().getrandbits(128))
-    JWT_ACCESS_TOKEN_EXPIRES = timedelta(minutes=1)
+    JWT_ACCESS_TOKEN_EXPIRES = timedelta(minutes=20)
+    JWT_REFRESH_TOKEN_EXPIRES = timedelta(days=30)
     # JWT_ACCESS_TOKEN_EXPIRES = timedelta(hours=1)
     JWT_TOKEN_LOCATION = ["cookies"]
     # Storing the tokens in cookies protects agains XSS attacks but is vulnerable to CSRF attacks.

--- a/4_client_server_db_jwt/server/default_config.py
+++ b/4_client_server_db_jwt/server/default_config.py
@@ -19,7 +19,8 @@ class DefaultConfig:
         "postgresql://postgres:postgres@localhost:5432/flatiron_labs"
     )
     JWT_SECRET_KEY = str(secrets.SystemRandom().getrandbits(128))
-    JWT_ACCESS_TOKEN_EXPIRES = timedelta(hours=1)
+    JWT_ACCESS_TOKEN_EXPIRES = timedelta(minutes=1)
+    # JWT_ACCESS_TOKEN_EXPIRES = timedelta(hours=1)
     JWT_TOKEN_LOCATION = ["cookies"]
     # Storing the tokens in cookies protects agains XSS attacks but is vulnerable to CSRF attacks.
     # Best practice will be to set this to True, but it requires a CSRF token to be sent with every request.

--- a/4_client_server_db_jwt/server/resources/user.py
+++ b/4_client_server_db_jwt/server/resources/user.py
@@ -10,6 +10,7 @@ from flask_jwt_extended import (
     get_jwt,
     jwt_required,
     set_access_cookies,
+    set_refresh_cookies,
     unset_jwt_cookies,
 )
 from flask_smorest import Blueprint, abort
@@ -59,14 +60,15 @@ class UsersLogin(MethodView):
             )
 
             # Set the JWT cookies in the response
-            set_access_cookies(resp, access_token, refresh_token)
+            set_access_cookies(resp, access_token)
+            set_refresh_cookies(resp, refresh_token)
             return resp, 200
 
         abort(401, message="Invalid credentials.")
 
 
 # update /authenticate to become our /refresh route
-@blp.route("/authenticate")
+@blp.route("/refresh")
 class UserAuthenticated(MethodView):
     # be default, jwt_required() checks for type="access" token
     @jwt_required(refresh=True)

--- a/4_client_server_db_jwt/server/resources/user.py
+++ b/4_client_server_db_jwt/server/resources/user.py
@@ -75,18 +75,8 @@ class UserAuthenticated(MethodView):
     @blp.doc(authorize=True)
     def get(self):
         """Check if user is authenticated."""
-        # looks like much of below is handled by token_in_blocklist_loader
-        # so just sending new access token back to client for now
-        # jti = get_jwt()["jti"]
-        # blocked = db.session.scalars(
-        #     select(TokenBlocklist).where(TokenBlocklist.jti == jti)
-        # ).first()
-        # if blocked:
-        #     abort(401, message="Token has been revoked.")
-
-        # user_id = get_jwt_identity()
-        # access_token = create_access_token(identity=user_id)
-        access_token = create_access_token(identity=current_user)
+        # although a new access token is created, we know it has been refreshed because the fresh parameter is set to False
+        access_token = create_access_token(identity=current_user, fresh=False)
         resp = jsonify({"access_token": access_token})
         set_access_cookies(resp, access_token)
         return resp, 200
@@ -94,7 +84,8 @@ class UserAuthenticated(MethodView):
 
 @blp.route("/logout")
 class UsersLogout(MethodView):
-    @jwt_required()
+    # refresh=True means only a refresh token is required; expired access tokens can pass
+    @jwt_required(refresh=True)
     @blp.doc(authorize=True)
     def post(self):
         """Revoke access token for authenticated user."""


### PR DESCRIPTION
This PR touches both client and server code:
- new callback on app.py examines expiry on access tokens after every request and refreshes if necessary
- new /refresh endpoint replaces /authenticate to explicitly renew tokens if there is a browser reload
- utility functions added to AuthProvider to enable token expiration checking
- client routing reworked with new wrapper route which checks for expired tokens and auto-logouts if expired
- StatusDetail shown to user before auto-logout (this feature can be expanded in future to provide button to refresh token)
- (games and rounds now sorted by number)

No unit test have been written yet for this verion of the Guessing Game (v4)